### PR TITLE
Rename POR options switches, purge mixed option

### DIFF
--- a/include/PetriEngine/options.h
+++ b/include/PetriEngine/options.h
@@ -43,9 +43,9 @@ enum class APCompression {
 enum class LTLPartialOrder {
     None,
     Visible,
-    AutomatonReach,
-    VisibleReach,
-    FullAutomaton
+    Automaton,
+    //VisibleAutomaton,
+    Liebke
 };
 
 enum class BuchiOptimization {
@@ -96,7 +96,7 @@ struct options_t {
     std::string buchi_out_file;
     LTL::BuchiOutType buchi_out_type = LTL::BuchiOutType::Dot;
     APCompression ltl_compress_aps = APCompression::None;
-    LTLPartialOrder ltl_por = LTLPartialOrder::VisibleReach;
+    LTLPartialOrder ltl_por = LTLPartialOrder::Automaton;
     BuchiOptimization buchiOptimization = BuchiOptimization::Low;
     LTLHeuristic ltlHeuristic = LTLHeuristic::Automaton;
 

--- a/include/PetriEngine/options.h
+++ b/include/PetriEngine/options.h
@@ -44,7 +44,6 @@ enum class LTLPartialOrder {
     None,
     Visible,
     Automaton,
-    //VisibleAutomaton,
     Liebke
 };
 

--- a/src/LTL/LTLMain.cpp
+++ b/src/LTL/LTLMain.cpp
@@ -126,15 +126,14 @@ namespace LTL {
         }
 
         bool is_visible_stub = options.stubbornreduction
-                               && (options.ltl_por == LTLPartialOrder::Visible || options.ltl_por == LTLPartialOrder::VisibleReach)
+                               && options.ltl_por == LTLPartialOrder::Visible
                                && !net->has_inhibitor()
                                && !PetriEngine::PQL::containsNext(negated_formula);
         bool is_autreach_stub = options.stubbornreduction
-                && (options.ltl_por == LTLPartialOrder::AutomatonReach ||
-                    options.ltl_por == LTLPartialOrder::VisibleReach)
+                && options.ltl_por == LTLPartialOrder::Automaton
                 && !net->has_inhibitor();
         bool is_buchi_stub = options.stubbornreduction
-                && options.ltl_por == LTLPartialOrder::FullAutomaton
+                && options.ltl_por == LTLPartialOrder::Liebke
                 && !net->has_inhibitor();
 
         bool is_stubborn = options.ltl_por != LTLPartialOrder::None && (is_visible_stub || is_autreach_stub || is_buchi_stub);

--- a/src/PetriEngine/options.cpp
+++ b/src/PetriEngine/options.cpp
@@ -138,16 +138,13 @@ void printHelp() {
         "  --partition-timeout <timeout>        Timeout for color partitioning in seconds (default 5)\n"
         "  -l, --lpsolve-timeout <timeout>      LPSolve timeout in seconds, default 10\n"
         "  -p, --disable-partial-order          Disable partial order reduction (stubborn sets)\n"
-        "  --ltl-por <type>                     Select partial order method to use with LTL engine (default reach).\n"
-        "                                       - reach      apply reachability stubborn sets in Büchi states\n"
-        "                                                    that represent reachability subproblems,\n"
-        "                                       - classic    classic stubborn set method.\n"
+        "  --ltl-por <type>                     Select partial order method to use with LTL engine (default automaton).\n"
+        "                                       - automaton  apply Büchi-guided stubborn set method.\n"
+        "                                       - classic    classic stubborn set method (Valmari, 1990).\n"
         "                                                    Only applicable with formulae that do not \n"
         "                                                    contain the next-step operator.\n"
-        "                                       - mix        mix of reach and classic - use reach when applicable,\n"
-        "                                                    classic otherwise.\n"
-        "                                       - automaton  apply fully Büchi-guided stubborn set method.\n"
-        "                                       - none       disable stubborn reductions (equivalent to -p).\n"
+        "                                       - liebke     apply POR method by Liebke (2020).\n"
+        "                                       - none       disable stubborn reductions for LTL model checking (equivalent to -p).\n"
         "  --ltl-heur <type>                    Select search heuristic for best-first search in LTL engine\n"
         "                                       Defaults to aut\n"
         "                                       - dist           Formula-driven heuristic, guiding toward states that satisfy\n"
@@ -462,12 +459,12 @@ bool options_t::parse(int argc, const char** argv) {
                 throw base_error("Missing argument to --ltl-por");
             } else if (std::strcmp(argv[i + 1], "classic") == 0) {
                 ltl_por = LTLPartialOrder::Visible;
-            } else if (std::strcmp(argv[i + 1], "reach") == 0) {
-                ltl_por = LTLPartialOrder::AutomatonReach;
-            } else if (std::strcmp(argv[i + 1], "mix") == 0) {
-                ltl_por = LTLPartialOrder::VisibleReach;
             } else if (std::strcmp(argv[i + 1], "automaton") == 0) {
-                ltl_por = LTLPartialOrder::FullAutomaton;
+                ltl_por = LTLPartialOrder::Automaton;
+            } else if (std::strcmp(argv[i + 1], "mix") == 0) {
+                ltl_por = LTLPartialOrder::Automaton;
+            } else if (std::strcmp(argv[i + 1], "liebke") == 0) {
+                ltl_por = LTLPartialOrder::Liebke;
             } else if (std::strcmp(argv[i + 1], "none") == 0) {
                 ltl_por = LTLPartialOrder::None;
             } else {

--- a/src/PetriEngine/options.cpp
+++ b/src/PetriEngine/options.cpp
@@ -139,7 +139,7 @@ void printHelp() {
         "  -l, --lpsolve-timeout <timeout>      LPSolve timeout in seconds, default 10\n"
         "  -p, --disable-partial-order          Disable partial order reduction (stubborn sets)\n"
         "  --ltl-por <type>                     Select partial order method to use with LTL engine (default automaton).\n"
-        "                                       - automaton  apply Büchi-guided stubborn set method.\n"
+        "                                       - automaton  apply Büchi-guided stubborn set method (Jensen et al., 2021).\n"
         "                                       - classic    classic stubborn set method (Valmari, 1990).\n"
         "                                                    Only applicable with formulae that do not \n"
         "                                                    contain the next-step operator.\n"


### PR DESCRIPTION
Clean-up of naming around POR methods. Our method is now named `automaton` and is set as default, whereas the one based on Liebke's theory is named `liebke`. The help message reflects this. The mixed option which would apply the classic method in non-reachability state has been purged as the notion of 'reachability state' is obsolete.

