### PR TITLE
Type of tokens during parsing

### DIFF
--- a/include/PetriEngine/AbstractPetriNetBuilder.h
+++ b/include/PetriEngine/AbstractPetriNetBuilder.h
@@ -38,7 +38,7 @@ namespace PetriEngine {
 
         /** Add a new place with a unique name */
         virtual void addPlace(const std::string& name,
-                int tokens,
+                uint32_t tokens,
                 double x,
                 double y) = 0;
         /** Add a new colored place with a unique name */

--- a/include/PetriEngine/Colored/ColoredPetriNetBuilder.h
+++ b/include/PetriEngine/Colored/ColoredPetriNetBuilder.h
@@ -44,7 +44,7 @@ namespace PetriEngine {
         virtual ~ColoredPetriNetBuilder();
 
         void addPlace(const std::string& name,
-                int tokens,
+                uint32_t tokens,
                 double x,
                 double y) override ;
         void addPlace(const std::string& name,

--- a/include/PetriEngine/PetriNetBuilder.h
+++ b/include/PetriEngine/PetriNetBuilder.h
@@ -38,7 +38,7 @@ namespace PetriEngine {
     public:
         PetriNetBuilder();
         PetriNetBuilder(const PetriNetBuilder& other);
-        void addPlace(const std::string& name, int tokens, double x, double y) override;
+        void addPlace(const std::string& name, uint32_t tokens, double x, double y) override;
         void addTransition(const std::string& name,
                 int32_t player,
                 double x,

--- a/src/PetriEngine/Colored/ColoredPetriNetBuilder.cpp
+++ b/src/PetriEngine/Colored/ColoredPetriNetBuilder.cpp
@@ -43,7 +43,7 @@ namespace PetriEngine {
         _colors.clear();
     }
 
-    void ColoredPetriNetBuilder::addPlace(const std::string& name, int tokens, double x, double y) {
+    void ColoredPetriNetBuilder::addPlace(const std::string& name, uint32_t tokens, double x, double y) {
         if (!_isColored) {
             _ptBuilder.addPlace(name, tokens, x, y);
         }

--- a/src/PetriEngine/PetriNetBuilder.cpp
+++ b/src/PetriEngine/PetriNetBuilder.cpp
@@ -45,7 +45,7 @@ namespace PetriEngine {
 
     }
 
-    void PetriNetBuilder::addPlace(const std::string &name, int tokens, double x, double y) {
+    void PetriNetBuilder::addPlace(const std::string &name, uint32_t tokens, double x, double y) {
         if(_placenames.count(name) == 0)
         {
             uint32_t next = _placenames.size();

--- a/src/PetriParse/PNMLParser.cpp
+++ b/src/PetriParse/PNMLParser.cpp
@@ -596,7 +596,7 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
     std::string id(element->first_attribute("id")->value());
 
     auto initial = element->first_attribute("initialMarking");
-    uint32_t initialMarking = 0;
+    uint64_t initialMarking = 0;
     PetriEngine::Colored::Multiset hlinitialMarking;
     const PetriEngine::Colored::ColorType* type = nullptr;
     if(initial)

--- a/src/PetriParse/PNMLParser.cpp
+++ b/src/PetriParse/PNMLParser.cpp
@@ -596,7 +596,7 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
     std::string id(element->first_attribute("id")->value());
 
     auto initial = element->first_attribute("initialMarking");
-    long long initialMarking = 0;
+    uint32_t initialMarking = 0;
     PetriEngine::Colored::Multiset hlinitialMarking;
     const PetriEngine::Colored::ColorType* type = nullptr;
     if(initial)
@@ -620,9 +620,9 @@ void PNMLParser::parsePlace(rapidxml::xml_node<>* element) {
         }
     }
 
-    if(initialMarking > std::numeric_limits<int>::max())
+    if(initialMarking > std::numeric_limits<uint32_t>::max())
     {
-        throw base_error("Number of tokens in ", id, " exceeded ", std::numeric_limits<int>::max());
+        throw base_error("Number of tokens in ", id, " exceeded ", std::numeric_limits<uint32_t>::max());
     }
     //Create place
     if (!isColored) {


### PR DESCRIPTION
Negative values for initial markings (and tokens) not needed. Changed to `uint32_t` from `int` in several places.

Most notably, the check for max numerical for initial marking was set to check `int` when in fact a `long long` was used. 
This made parsing for the model `GPPP-PT-C0010N1000000000` fail, as it has a marking of `4000000000`, which is larger than what an `int` can handle.

With the changes to the initial marking, and check of this, we can now parse `GPPP-PT-C0010N1000000000` and solve all queries in ReachabilityCardinality category (even very quickly, getting us some 16 more answers here), have not checked results in others. But at least we can now parse the model.

Made changes to other types, as we found this, but the main thing is with the initial marking. 