### PR TITLE
Fixed issue where <?xml tag was included in trace output

### DIFF
--- a/src/LTL/Algorithm/NestedDepthFirstSearch.cpp
+++ b/src/LTL/Algorithm/NestedDepthFirstSearch.cpp
@@ -161,8 +161,7 @@ namespace LTL {
     template<typename S>
     void NestedDepthFirstSearch<S>::print_trace(light_deque<StackEntry>& _todo, light_deque<StackEntry>& _nested_todo, std::ostream &os)
     {
-        os << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-              "<trace>\n";
+        os << "<trace>\n";
         if(this->_reducer)
             this->_reducer->initFire(os);
         size_t loop_id = std::numeric_limits<size_t>::max();

--- a/src/LTL/Algorithm/TarjanModelChecker.cpp
+++ b/src/LTL/Algorithm/TarjanModelChecker.cpp
@@ -211,8 +211,7 @@ namespace LTL {
             return;
         } else {
             assert(_violation);
-            os << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                  "<trace>\n";
+            os << "<trace>\n";
             this->_reducer->initFire(os);
             if (_cstack[dstack.top()._pos]._stateid == _loop_state)
                 this->printLoop(os);


### PR DESCRIPTION
TarJan and NestedDFS trace outputs included a unclosed <xml> tag, ignored in the gui. Removed to clean up. 