### PR TITLE
Throw error on tuple-tuple comparison

### DIFF
--- a/src/PetriEngine/Colored/EvaluationVisitor.cpp
+++ b/src/PetriEngine/Colored/EvaluationVisitor.cpp
@@ -60,6 +60,7 @@ namespace PetriEngine {
             (*e)[0]->visit(*this);
             auto lhs = _cres;
             (*e)[1]->visit(*this);
+            if (lhs->isTuple() || _cres->isTuple()) throw base_error("Tuple-tuple comparison are not allowed: Unknown semantics");
             _bres = lhs < _cres;
         }
 
@@ -67,6 +68,7 @@ namespace PetriEngine {
             (*e)[0]->visit(*this);
             auto lhs = _cres;
             (*e)[1]->visit(*this);
+            if (lhs->isTuple() || _cres->isTuple()) throw base_error("Tuple-tuple comparison are not allowed: Unknown semantics");
             _bres = lhs <= _cres;
         }
 
@@ -74,6 +76,7 @@ namespace PetriEngine {
             (*e)[0]->visit(*this);
             auto lhs = _cres;
             (*e)[1]->visit(*this);
+            if (lhs->isTuple() || _cres->isTuple()) throw base_error("Tuple-tuple comparison are not allowed: Unknown semantics");
             _bres = lhs == _cres;
         }
 
@@ -81,6 +84,7 @@ namespace PetriEngine {
             (*e)[0]->visit(*this);
             auto lhs = _cres;
             (*e)[1]->visit(*this);
+            if (lhs->isTuple() || _cres->isTuple()) throw base_error("Tuple-tuple comparison are not allowed: Unknown semantics");
             _bres = lhs != _cres;
         }
 


### PR DESCRIPTION
At a recent meeting with @petergjoel and @srba, we discussed the semantics of tuple-tuple comparisons on CPN guards. The engine uses lexicographical comparison according to Peter, but we do actually not know what the correct semantics are according to the pnml format.

This PR will make verifypn throw an exception if it encounters any tuple-tuple comparisons. I ran this branch on MCC2021 and can conclude that there are no tuple-tuple comparisons at the moment.