### PR TITLE
rule-i fix inconsistencies

### DIFF
--- a/include/PetriEngine/Reducer.h
+++ b/include/PetriEngine/Reducer.h
@@ -134,7 +134,7 @@ namespace PetriEngine {
         bool ReducebyRuleC(uint32_t* placeInQuery);
         bool ReducebyRuleD(uint32_t* placeInQuery);
         bool ReducebyRuleE(uint32_t* placeInQuery);
-        bool ReducebyRuleI(uint32_t* placeInQuery, bool remove_loops, bool remove_consumers);
+        bool ReducebyRuleI(uint32_t* placeInQuery, bool remove_consumers);
         bool ReducebyRuleF(uint32_t* placeInQuery);
         bool ReducebyRuleG(uint32_t* placeInQuery, bool remove_loops, bool remove_consumers);
         bool ReducebyRuleH(uint32_t* placeInQuery);


### PR DESCRIPTION
Reduction: Removed the case for loop sensitive application of rule I. It causes inconsistencies on queries that include 'EF deadlock', which are the only cases where it did not overlap with rule F. 

Example shown below, with the query `EF deadlock` . 
In this net Rule I would remove `T1`, `P2` and `P4`, and thus remove a possibility for a deadlock

![image](https://user-images.githubusercontent.com/33687173/164617214-2f1bd242-00e4-4d7a-9326-a0b938bcf0a1.png)
