### PR TITLE
Small edge cases + fixing big mistake concerning deadlock and LTL

### DIFF
--- a/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
@@ -11,7 +11,7 @@
 
 namespace PetriEngine::Colored::Reduction {
     bool RedRulePreAgglomeration::isApplicable(QueryType queryType, bool preserveLoops, bool preserveStutter) const {
-        return queryType != CTL && !preserveStutter;
+        return (queryType == Reach) && !preserveLoops;
     }
 
     bool RedRulePreAgglomeration::apply(ColoredReducer &red, const PetriEngine::PQL::ColoredUseVisitor &inQuery,

--- a/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
@@ -188,7 +188,7 @@ namespace PetriEngine::Colored::Reduction {
                         // S11
                         if (!kIsAlwaysOne[n]) {
                             for (const auto& conspost : consumer.output_arcs) {
-                                if (red.places()[conspost.place].inhibitor || (queryType != Reach && inQuery.isPlaceUsed(conspost.place))) {
+                                if (red.places()[conspost.place].inhibitor) {
                                     ok = false;
                                     break;
                                 }

--- a/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
@@ -5,6 +5,7 @@
  *      Mathias Mehl Sørensen
  */
 
+#include <PetriEngine/Colored/VariableVisitor.h>
 #include "PetriEngine/Colored/Reduction/RedRulePreAgglomeration.h"
 #include "PetriEngine/Colored/Reduction/ColoredReducer.h"
 

--- a/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRulePreAgglomeration.cpp
@@ -124,7 +124,7 @@ namespace PetriEngine::Colored::Reduction {
                             } else if (kw != w) {
                                 kIsAlwaysOne[n] = false;
                             }
-                        } else if (!consArc->expr->is_single_color() || kw != w) {
+                        } else if (!consArc->expr->is_single_color() || kw != w || consumer.input_arcs.size() != 1) {
                             ok = false;
                             break;
                         }
@@ -178,8 +178,8 @@ namespace PetriEngine::Colored::Reduction {
 
                     const Transition &consumer = red.transitions()[originalConsumers[n]];
                     if (consumer.guard != nullptr) continue;
-
-                    // T trivially passes these because of T5 earlier
+                    
+                    // T5 and T12 have this covered already for the non-atomic case
                     if (atomic_viable){
                         // S12
                         if (!kIsAlwaysOne[n] && consumer.input_arcs.size() != 1) {
@@ -194,9 +194,9 @@ namespace PetriEngine::Colored::Reduction {
                                 }
                             }
                         }
+                        if (!ok) continue;
                     }
-                    if (!ok) continue;
-
+                    
                     const auto& consArc = red.getInArc(pid, consumer);
                     uint32_t w = consArc->expr->weight();
                     


### PR DESCRIPTION
The change around line 254 should fix the problem with deadlocks. The assumption that we needed to keep those transitions around was mistaken. The other changes are things that I'm unsure of whether the old implementation was entirely correct on, so i included them too.