### PR TITLE
Optimization in CTL: Discard hyperedges with self-loop

### DIFF
--- a/include/CTL/DependencyGraph/Edge.h
+++ b/include/CTL/DependencyGraph/Edge.h
@@ -21,14 +21,20 @@ public:
     Edge(){}
     Edge(Configuration &t_source) : source(&t_source) {}
 
-    void addTarget(Configuration* conf)
+    bool addTarget(Configuration* conf)
     {
+        if(handled) return true;
         assert(conf);
-        targets.push_front(conf);
-        //++children;
+        if(conf == source)
+        {
+            handled = true;
+            targets.clear();
+        }
+        else targets.push_front(conf);
+        return handled;
     }
-    
-    container targets;    
+
+    container targets;
     Configuration* source;
     uint8_t status = 0;
     bool processed = false;

--- a/src/CTL/Algorithm/CertainZeroFPA.cpp
+++ b/src/CTL/Algorithm/CertainZeroFPA.cpp
@@ -70,7 +70,6 @@ void Algorithm::CertainZeroFPA::checkEdge(Edge* e, bool only_assign)
 
     bool allOne = true;
     bool hasCZero = false;
-    bool has_loop = false;
     //auto pre_empty = e->targets.empty();
     Configuration *lastUndecided = nullptr;
     {
@@ -78,10 +77,6 @@ void Algorithm::CertainZeroFPA::checkEdge(Edge* e, bool only_assign)
         auto pit = e->targets.before_begin();
         while(it != e->targets.end())
         {
-            if ((*it) == e->source) {
-                has_loop = true;
-                break;
-            }
             if ((*it)->assignment == ONE)
             {
                 e->targets.erase_after(pit);
@@ -107,17 +102,6 @@ void Algorithm::CertainZeroFPA::checkEdge(Edge* e, bool only_assign)
             pit = it;
             ++it;
         }
-    }
-    if (has_loop) {
-        --e->source->nsuccs;
-        e->handled = true;
-        assert(e->refcnt > 0);
-        if(only_assign) --e->refcnt;
-        if (e->source->nsuccs == 0) {
-            finalAssign(e, CZERO);
-        }
-        if(e->refcnt == 0) { graph->release(e);}
-        return;
     }
     /*if(e->targets.empty())
     {

--- a/src/CTL/PetriNets/OnTheFlyDG.cpp
+++ b/src/CTL/PetriNets/OnTheFlyDG.cpp
@@ -199,7 +199,8 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                                     if(res == Condition::RFALSE)
                                     {
                                         left = nullptr;
-                                        leftEdge->targets.clear();
+                                        --leftEdge->refcnt;
+                                        release(leftEdge);
                                         leftEdge = nullptr;
                                         return false;
                                     }
@@ -217,6 +218,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                                         if (leftEdge->handled){
                                             --leftEdge->refcnt;
                                             release(leftEdge);
+                                            leftEdge = nullptr;
                                         }
                                         else
                                             succs.push_back(leftEdge);

--- a/src/CTL/PetriNets/OnTheFlyDG.cpp
+++ b/src/CTL/PetriNets/OnTheFlyDG.cpp
@@ -56,15 +56,6 @@ Condition::Result OnTheFlyDG::fastEval(Condition* query, Marking* unfolded)
     return PetriEngine::PQL::evaluate(query, e);
 }
 
-void add_target(Edge* e, Configuration* c) {
-    if (c == e->source) {
-        e->handled = true;
-    }
-    else {
-        e->addTarget(c);
-    }
-}
-
 std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
 {
     PetriEngine::PQL::DistanceContext context(net, query_marking.marking());
@@ -88,8 +79,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
             Configuration* c = createConfiguration(v->marking, v->getOwner(), (*cond)[0]);
             Edge* e = newEdge(*v, /*v->query->distance(context)*/0);
             e->is_negated = true;
-            add_target(e, c);
-            if (!e->handled) {
+            if (!e->addTarget(c)) {
                 succs.push_back(e);
             }
             else {
@@ -122,8 +112,8 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
             for(auto c : conds)
             {
                 assert(PetriEngine::PQL::isTemporal(c));
-                add_target(e, createConfiguration(v->marking, v->getOwner(), c));
-                if (e->handled) break;
+                if (e->addTarget(createConfiguration(v->marking, v->getOwner(), c)))
+                    break;
             }
             if (e->handled) {
                 --e->refcnt;
@@ -157,8 +147,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
             {
                 assert(PetriEngine::PQL::isTemporal(c));
                 Edge *e = newEdge(*v, /*cond->distance(context)*/0);
-                add_target(e, createConfiguration(v->marking, v->getOwner(), c));
-                if (e->handled) {
+                if (e->addTarget(createConfiguration(v->marking, v->getOwner(), c))) {
                     --e->refcnt;
                     release(e);
                 }
@@ -174,7 +163,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
         if(v->query->getQuantifier() == A){
             if (v->query->getPath() == U){
                 auto cond = static_cast<AUCondition*>(v->query);
-                Edge *right = NULL;
+                Edge *right = nullptr;
                 auto r1 = fastEval((*cond)[1], &query_marking);
                 if (r1 != Condition::RUNKNOWN){
                     //right side is not temporal, eval it right now!
@@ -187,10 +176,10 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                     //right side is temporal, we need to evaluate it as normal
                     Configuration* c = createConfiguration(v->marking, v->getOwner(), (*cond)[1]);
                     right = newEdge(*v, /*(*cond)[1]->distance(context)*/0);
-                    add_target(right, c);
+                    right->addTarget(c);
                 }
                 bool valid = false;
-                Configuration *left = NULL;
+                Configuration *left = nullptr;
                 auto r0 = fastEval((*cond)[0], &query_marking);
                 if (r0 != Condition::RUNKNOWN) {
                     //left side is not temporal, eval it right now!
@@ -199,9 +188,9 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                     //left side is temporal, include it in the edge
                     left = createConfiguration(v->marking, v->getOwner(), (*cond)[0]);
                 }
-                if (valid || left != NULL) {
+                if (valid || left != nullptr) {
                     //if left side is guaranteed to be not satisfied, skip successor generation
-                    Edge* leftEdge = NULL;
+                    Edge* leftEdge = nullptr;
                     nextStates (query_marking, cond,
                                 [&](){ leftEdge = newEdge(*v, std::numeric_limits<uint32_t>::max());},
                                 [&](Marking& mark){
@@ -216,15 +205,14 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                                     }
                                     context.setMarking(mark.marking());
                                     Configuration* c = createConfiguration(createMarking(mark), owner(mark, cond), cond);
-                                    add_target(leftEdge, c);
-                                    return !leftEdge->handled;
+                                    return !leftEdge->addTarget(c);
                                 },
                                 [&]()
                                 {
                                     if(leftEdge)
                                     {
-                                        if (left != NULL) {
-                                            add_target(leftEdge, left);
+                                        if (left != nullptr) {
+                                            leftEdge->addTarget(left);
                                         }
                                         if (leftEdge->handled){
                                             --leftEdge->refcnt;
@@ -237,7 +225,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                             );
                 } //else: Left side is not temporal and it's false, no way to succeed there...
 
-                if (right != NULL) {
+                if (right != nullptr) {
                     if (right->handled){
                         --right->refcnt;
                         release(right);
@@ -248,7 +236,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
             }
             else if(v->query->getPath() == F){
                 auto cond = static_cast<AFCondition*>(v->query);
-                Edge *subquery = NULL;
+                Edge *subquery = nullptr;
                 auto r = fastEval((*cond)[0], &query_marking);
                 if (r != Condition::RUNKNOWN) {
                     bool valid = r == Condition::RTRUE;
@@ -259,9 +247,9 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                 } else {
                     subquery = newEdge(*v, /*cond->distance(context)*/0);
                     Configuration* c = createConfiguration(v->marking, v->getOwner(), (*cond)[0]);
-                    add_target(subquery, c); // cannot be self-loop since the formula is smaller
+                    subquery->addTarget(c); // cannot be self-loop since the formula is smaller
                 }
-                Edge* e1 = NULL;
+                Edge* e1 = nullptr;
                 nextStates(query_marking, cond,
                         [&](){e1 = newEdge(*v, std::numeric_limits<uint32_t>::max());},
                         [&](Marking& mark)
@@ -281,8 +269,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                             }
                             context.setMarking(mark.marking());
                             Configuration* c = createConfiguration(createMarking(mark), owner(mark, cond), cond);
-                            add_target(e1, c);
-                            return !e1->handled;
+                            return !e1->addTarget(c);
                         },
                         [&]()
                         {
@@ -320,7 +307,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                                 allValid = Condition::RUNKNOWN;
                                 context.setMarking(mark.marking());
                                 Configuration* c = createConfiguration(createMarking(mark), v->getOwner(), (*cond)[0]);
-                                add_target(e, c);
+                                e->addTarget(c);
                             }
                             return true;
                         },
@@ -348,12 +335,12 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
         else if(v->query->getQuantifier() == E){
             if (v->query->getPath() == U){
                 auto cond = static_cast<EUCondition*>(v->query);
-                Edge *right = NULL;
+                Edge *right = nullptr;
                 auto r1 = fastEval((*cond)[1], &query_marking);
                 if (r1 == Condition::RUNKNOWN) {
                     Configuration* c = createConfiguration(v->marking, v->getOwner(), (*cond)[1]);
                     right = newEdge(*v, /*(*cond)[1]->distance(context)*/0);
-                    add_target(right, c);
+                    right->addTarget(c);
                 } else {
                     bool valid = r1 == Condition::RTRUE;
                     if (valid) {
@@ -363,7 +350,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                 }
 
 
-                Configuration *left = NULL;
+                Configuration *left = nullptr;
                 bool valid = false;
                 nextStates(query_marking, cond,
                     [&](){
@@ -375,7 +362,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                         }
                     },
                     [&](Marking& marking){
-                        if(left == NULL && !valid) return false;
+                        if(left == nullptr && !valid) return false;
                         auto res = fastEval(cond, &marking);
                         if(res == Condition::RFALSE) return true;
                         if(res == Condition::RTRUE)
@@ -394,18 +381,16 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                             }
 
                             if(left)
-                            {
-                                add_target(succs.back(), left);
-                            }
+                                succs.back()->addTarget(left);
 
                             return false;
                         }
                         context.setMarking(marking.marking());
                         Edge* e = newEdge(*v, /*cond->distance(context)*/0);
                         Configuration* c1 = createConfiguration(createMarking(marking), owner(marking, cond), cond);
-                        add_target(e, c1);
-                        if (left != NULL) {
-                            add_target(e, left);
+                        e->addTarget(c1);
+                        if (left != nullptr) {
+                            e->addTarget(left);
                         }
                         if (e->handled) {
                             --e->refcnt;
@@ -428,7 +413,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
             }
             else if(v->query->getPath() == F){
                 auto cond = static_cast<EFCondition*>(v->query);
-                Edge *subquery = NULL;
+                Edge *subquery = nullptr;
                 auto r = fastEval((*cond)[0], &query_marking);
                 if (r != Condition::RUNKNOWN) {
                     bool valid = r == Condition::RTRUE;
@@ -439,7 +424,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                 } else {
                     Configuration* c = createConfiguration(v->marking, v->getOwner(), (*cond)[0]);
                     subquery = newEdge(*v, /*cond->distance(context)*/0);
-                    add_target(subquery, c);
+                    subquery->addTarget(c);
                 }
 
                 nextStates(query_marking, cond,
@@ -463,7 +448,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                                 context.setMarking(mark.marking());
                                 Edge* e = newEdge(*v, /*cond->distance(context)*/0);
                                 Configuration* c = createConfiguration(createMarking(mark), owner(mark, cond), cond);
-                                add_target(e, c);
+                                e->addTarget(c);
                                 if (!e->handled)
                                     succs.push_back(e);
                                 else {
@@ -475,7 +460,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                             [](){}
                         );
 
-                if (subquery != NULL) {
+                if (subquery != nullptr) {
                     succs.push_back(subquery);
                 }
             }
@@ -498,7 +483,7 @@ std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)
                                 context.setMarking(marking.marking());
                                 Edge* e = newEdge(*v, /*(*cond)[0]->distance(context)*/0);
                                 Configuration* c = createConfiguration(createMarking(marking), v->getOwner(), query);
-                                add_target(e, c);
+                                e->addTarget(c);
                                 succs.push_back(e);
                             }
                             return true;

--- a/src/CTL/PetriNets/OnTheFlyDG.cpp
+++ b/src/CTL/PetriNets/OnTheFlyDG.cpp
@@ -58,9 +58,11 @@ Condition::Result OnTheFlyDG::fastEval(Condition* query, Marking* unfolded)
 
 void add_target(Edge* e, Configuration* c) {
     if (c == e->source) {
-        e->handled = true; return; // TODO can be a return code for boolean instead?
+        e->handled = true;
     }
-    e->addTarget(c);
+    else {
+        e->addTarget(c);
+    }
 }
 
 std::vector<DependencyGraph::Edge*> OnTheFlyDG::successors(Configuration *c)

--- a/src/LTL/Algorithm/TarjanModelChecker.cpp
+++ b/src/LTL/Algorithm/TarjanModelChecker.cpp
@@ -116,7 +116,7 @@ namespace LTL {
                 if (!next_trans(seen, cstack, successorGenerator, working, parent, dtop)) {
                     ++_expanded;
 #ifndef NDEBUG
-                    std::cerr << "backtrack\n";
+                    //std::cerr << "backtrack\n";
 #endif
                     pop(seen, cstack, dstack, successorGenerator);
                     continue;
@@ -127,7 +127,7 @@ namespace LTL {
                 successorGenerator.fired();
 #ifndef NDEBUG
                 if (fired >= std::numeric_limits<uint32_t>::max() - 3) {
-                    std::cerr << "looping\n";
+                    //std::cerr << "looping\n";
                 }
 #endif
                 ++_explored;

--- a/src/LTL/Stubborn/SafeAutStubbornSet.cpp
+++ b/src/LTL/Stubborn/SafeAutStubbornSet.cpp
@@ -94,7 +94,7 @@ namespace LTL {
     }
 
     void SafeAutStubbornSet::_print_debug() {
-#ifndef NDEBUG
+#ifndef STUBBORN_STATISTICS
         float num_stubborn = 0;
         float num_enabled = 0;
         float num_enabled_stubborn = 0;

--- a/src/LTL/Stubborn/SafeAutStubbornSet.cpp
+++ b/src/LTL/Stubborn/SafeAutStubbornSet.cpp
@@ -94,7 +94,7 @@ namespace LTL {
     }
 
     void SafeAutStubbornSet::_print_debug() {
-#ifndef STUBBORN_STATISTICS
+#ifdef STUBBORN_STATISTICS
         float num_stubborn = 0;
         float num_enabled = 0;
         float num_enabled_stubborn = 0;


### PR DESCRIPTION
This patch stops OnTheFlyDG from generating hyperedges $(v, T)$ where $v \in T$, as those edges cannot possibly improve the value of $v$ to 1 either way. This results in a good number of additional answers with no observed inconsistencies.

Note that doing this optimization in OnTheFlyDG gives a few more answers than doing it in CertainZeroFPA (as done in commit 2b913445 on this branch), and only does the check once per edge rather than each time an edge is checked, see benchmark below.

Benchmarks: number of queries solved, with 5 minutes and 15 GiB memory per query on mcc2021:
- Trunk 044327e8: 26908/37792 (71.2%) of answers.
- This branch, 2b913445: 27179/37792 (71.91%) of answers.
- CZero version, 9cc4a124 (earlier on this branch): 27162/37792 (71.87%) of answers.

This branch loses 19 answers but gains 294 compared to the baseline. I haven't yet looked in detail at time/memory gains between the versions.

