### PR TITLE
adding max token count to CTL statistics output

### DIFF
--- a/boost_tests/models/ltl_kbound.pnml
+++ b/boost_tests/models/ltl_kbound.pnml
@@ -1,0 +1,18 @@
+<pnml>
+<net id="ComposedModel" type="P/T net">
+<place id="TAPN1_P0" name="TAPN1_P0" invariant="&lt; inf" initialMarking="1" >
+<graphics><position x="330" y="300" /></graphics></place>
+<place id="TAPN1_P1" name="TAPN1_P1" invariant="&lt; inf" initialMarking="0" >
+<graphics><position x="645" y="300" /></graphics></place>
+<place id="TAPN1_P2" name="TAPN1_P2" invariant="&lt; inf" initialMarking="0" >
+<graphics><position x="930" y="300" /></graphics></place>
+<transition player="0" id="TAPN1_T0" name="TAPN1_T0" urgent="false">
+<graphics><position x="465" y="300" /></graphics></transition>
+<transition player="0" id="TAPN1_T1" name="TAPN1_T1" urgent="false">
+<graphics><position x="810" y="300" /></graphics></transition>
+<inputArc source="TAPN1_P0" target="TAPN1_T0"><inscription><value>1</value></inscription></inputArc>
+<inputArc source="TAPN1_P1" target="TAPN1_T1"><inscription><value>2</value></inscription></inputArc>
+<outputArc source="TAPN1_T0" target="TAPN1_P1"><inscription><value>2</value></inscription></outputArc>
+<outputArc source="TAPN1_T1" target="TAPN1_P2"><inscription><value>2</value></inscription></outputArc>
+</net>
+</pnml>

--- a/boost_tests/models/ltl_kbound.xml
+++ b/boost_tests/models/ltl_kbound.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<property-set xmlns="http://tapaal.net/">
+  
+  <property>
+    <id>Query Comment/Name Here</id>
+    <description>Query Comment/Name Here</description>
+    <formula>
+      <exists-path>
+        <globally>
+          <integer-eq>
+            <tokens-count>
+              <place>TAPN1_P2</place>
+            </tokens-count>
+            <integer-constant>0</integer-constant>
+          </integer-eq>
+        </globally>
+      </exists-path>
+    </formula>
+  </property>
+</property-set>

--- a/include/CTL/CTLResult.h
+++ b/include/CTL/CTLResult.h
@@ -26,6 +26,7 @@ struct CTLResult {
     size_t processedNegationEdges = 0;
     size_t exploredConfigurations = 0;
     size_t numberOfEdges = 0;
+    size_t maxTokens = 0;
 #ifdef VERIFYPNDIST
     size_t numberOfRoundsComputingDistance = 0;
     size_t numberOfTokensReceived = 0;

--- a/include/CTL/PetriNets/OnTheFlyDG.h
+++ b/include/CTL/PetriNets/OnTheFlyDG.h
@@ -44,7 +44,7 @@ public:
     //stats
     size_t configurationCount() const;
     size_t markingCount() const;
-
+    size_t maxTokens() const;
     Condition::Result initialEval();
 
 protected:
@@ -58,6 +58,7 @@ protected:
     uint32_t n_transitions = 0;
     uint32_t n_places = 0;
     size_t _markingCount = 0;
+    size_t _maxTokens = 0;
     size_t _configurationCount = 0;
     //used after query is set
     Condition* query = nullptr;

--- a/include/LTL/Algorithm/ModelChecker.h
+++ b/include/LTL/Algorithm/ModelChecker.h
@@ -74,6 +74,8 @@ namespace LTL {
             return _loop;
         }
 
+        virtual size_t max_tokens() const = 0;
+
         const std::vector<size_t>& trace() const {
             return _trace;
         }

--- a/include/LTL/Algorithm/NestedDepthFirstSearch.h
+++ b/include/LTL/Algorithm/NestedDepthFirstSearch.h
@@ -53,6 +53,8 @@ namespace LTL {
 
         void print_stats(std::ostream &os) const override;
 
+        virtual size_t max_tokens() const override;
+
     private:
         using State = LTL::Structures::ProductState;
         std::pair<bool,size_t> mark(State& state, uint8_t);

--- a/include/LTL/Algorithm/TarjanModelChecker.h
+++ b/include/LTL/Algorithm/TarjanModelChecker.h
@@ -60,6 +60,8 @@ namespace LTL {
 
         void print_stats(std::ostream &os) const override;
 
+        virtual size_t max_tokens() const override;
+
         virtual void set_partial_order(LTLPartialOrder);
 
         LTLPartialOrder used_partial_order() const {

--- a/include/LTL/LTLSearch.h
+++ b/include/LTL/LTLSearch.h
@@ -73,6 +73,10 @@ namespace LTL {
             return _checker->is_weak();
         }
 
+        size_t max_tokens() const {
+            return _checker->max_tokens();
+        }
+
         std::string heuristic_type() const {
             std::stringstream ss;
             if(_heuristic)

--- a/include/PetriEngine/Reachability/ReachabilitySearch.h
+++ b/include/PetriEngine/Reachability/ReachabilitySearch.h
@@ -62,6 +62,7 @@ namespace PetriEngine {
                     bool printstats,
                     bool keep_trace,
                     size_t seed);
+            size_t maxTokens() const;
         private:
             struct searchstate_t {
                 size_t expandedStates = 0;
@@ -89,6 +90,7 @@ namespace PetriEngine {
             size_t _satisfyingMarking = 0;
             Structures::State _initial;
             AbstractHandler& _callback;
+            size_t _max_tokens = 0;
         };
 
         template <typename G>
@@ -136,8 +138,10 @@ namespace PetriEngine {
                 {
                     if(checkQueries(queries, results, working, ss, &states))
                     {
-                        if(printstats) printStats(ss, &states);
-                            return true;
+                        if(printstats)
+                            printStats(ss, &states);
+                        _max_tokens = states.maxTokens();
+                        return true;
                     }
                 }
                 // add initial to queue
@@ -163,7 +167,9 @@ namespace PetriEngine {
                             _satisfyingMarking = res.second;
                             ss.exploredStates++;
                             if (checkQueries(queries, results, working, ss, &states)) {
-                                if(printstats) printStats(ss, &states);
+                                if(printstats)
+                                    printStats(ss, &states);
+                                _max_tokens = states.maxTokens();
                                 return true;
                             }
                         }
@@ -181,7 +187,9 @@ namespace PetriEngine {
                 }
             }
 
-            if(printstats) printStats(ss, &states);
+            if(printstats)
+                printStats(ss, &states);
+            _max_tokens = states.maxTokens();
             return false;
         }
 

--- a/src/CTL/CTLResult.cpp
+++ b/src/CTL/CTLResult.cpp
@@ -28,6 +28,7 @@ void CTLResult::print(const std::string& qname, bool statisticslevel, size_t ind
         out << "	Processed Edges   : " << processedEdges << "\n";
         out << "	Processed N. Edges: " << processedNegationEdges << "\n";
         out << "	Explored Configs  : " << exploredConfigurations << "\n";
+        out << "	max tokens:       : " << maxTokens << "\n"; // kept lower case to be compatible with reachability format 
     }
     out << std::endl;
 }

--- a/src/CTL/PetriNets/OnTheFlyDG.cpp
+++ b/src/CTL/PetriNets/OnTheFlyDG.cpp
@@ -580,6 +580,10 @@ size_t OnTheFlyDG::markingCount() const
     return _markingCount;
 }
 
+size_t OnTheFlyDG::maxTokens() const {
+    return _maxTokens;
+}
+
 PetriConfig *OnTheFlyDG::createConfiguration(size_t marking, size_t own, Condition* t_query)
 {
     auto& configs = trie.get_data(marking);
@@ -614,6 +618,7 @@ size_t OnTheFlyDG::createMarking(Marking& t_marking){
     auto tit = trie.insert(w.raw(), w.size());
     if(tit.first){
         _markingCount++;
+        _maxTokens = std::max(sum, _maxTokens);
     }
 
     return tit.second;

--- a/src/LTL/Algorithm/NestedDepthFirstSearch.cpp
+++ b/src/LTL/Algorithm/NestedDepthFirstSearch.cpp
@@ -154,6 +154,10 @@ namespace LTL {
         }
     }
 
+    size_t NestedDepthFirstSearch::max_tokens() const {
+        return _states.max_tokens();
+    }
+
     void NestedDepthFirstSearch::print_stats(std::ostream &os) const
     {
         ModelChecker::print_stats(os, _states.discovered(), _states.max_tokens());

--- a/src/LTL/Algorithm/TarjanModelChecker.cpp
+++ b/src/LTL/Algorithm/TarjanModelChecker.cpp
@@ -24,6 +24,10 @@ namespace LTL {
         ModelChecker::print_stats(os, _discoverd, _max_tokens);
     }
 
+    size_t TarjanModelChecker::max_tokens() const {
+        return _max_tokens;
+    }
+
     void TarjanModelChecker::set_partial_order(LTLPartialOrder o)
     {
         if(_net.has_inhibitor())

--- a/src/PetriEngine/Reachability/ReachabilitySearch.cpp
+++ b/src/PetriEngine/Reachability/ReachabilitySearch.cpp
@@ -122,6 +122,10 @@ namespace PetriEngine {
                        else TEMPPAR(X, SuccessorGenerator)
 
 
+        size_t ReachabilitySearch::maxTokens() const {
+            return _max_tokens;
+        }
+
         bool ReachabilitySearch::reachable(
                     std::vector<std::shared_ptr<PQL::Condition > >& queries,
                     std::vector<ResultPrinter::Result>& results,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -428,7 +428,6 @@ int main(int argc, const char** argv) {
 
                     if(options.trace != TraceLevel::None)
                         search.print_trace(std::cerr, *builder.getReducer());
-
                 }
 
                 if (std::find(results.begin(), results.end(), ResultPrinter::Unknown) == results.end()) {


### PR DESCRIPTION
Adds token count output (and computation) to CTL. 
Notice that it is hard to say anything conclusive about CTL if we hit the bound.
For LTL, the trace is valid if we find a trace -- otherwise the result is inconclusive. 