### PR TITLE
extended CTL Statistics

### DIFF
--- a/include/LTL/Algorithm/ModelChecker.h
+++ b/include/LTL/Algorithm/ModelChecker.h
@@ -64,9 +64,19 @@ namespace LTL {
             return _shortcircuitweak;
         }
 
-        size_t get_explored() {
+        size_t get_explored() const {
             return _explored;
         }
+
+        size_t get_expanded() const {
+            return _expanded;
+        }
+
+        virtual size_t get_discovered() const = 0;
+
+        virtual size_t get_markings() const = 0;
+
+        virtual size_t get_configurations() const = 0;
 
         virtual void print_stats(std::ostream&) const = 0;
 

--- a/include/LTL/Algorithm/NestedDepthFirstSearch.h
+++ b/include/LTL/Algorithm/NestedDepthFirstSearch.h
@@ -55,6 +55,12 @@ namespace LTL {
 
         virtual size_t max_tokens() const override;
 
+        virtual size_t get_discovered() const override;
+
+        virtual size_t get_markings() const override;
+
+        virtual size_t get_configurations() const override;
+
     private:
         using State = LTL::Structures::ProductState;
 
@@ -66,6 +72,8 @@ namespace LTL {
         const uint32_t _hyper_traces = 0;
         size_t _discovered = 0;
         size_t _max_tokens = 0;
+        size_t _markings = 0;
+        size_t _configurations = 0;
 
         template<typename T>
         struct stack_entry_t {

--- a/include/LTL/Algorithm/TarjanModelChecker.h
+++ b/include/LTL/Algorithm/TarjanModelChecker.h
@@ -64,6 +64,12 @@ namespace LTL {
 
         virtual size_t max_tokens() const override;
 
+        virtual size_t get_discovered() const override;
+
+        virtual size_t get_markings() const override;
+
+        virtual size_t get_configurations() const override;
+
         virtual void set_partial_order(LTLPartialOrder);
 
         LTLPartialOrder used_partial_order() const {
@@ -127,6 +133,8 @@ namespace LTL {
         uint32_t _loop_trans = std::numeric_limits<uint32_t>::max();
         size_t _discoverd = std::numeric_limits<size_t>::max();
         size_t _max_tokens = std::numeric_limits<size_t>::max();
+        size_t _markings = 0;
+        size_t _configurations = 0;
         const uint32_t _k_bound = 0;
         const uint32_t _hyper_traces = 0;
         LTLPartialOrder _order = LTLPartialOrder::None;

--- a/include/LTL/LTLSearch.h
+++ b/include/LTL/LTLSearch.h
@@ -78,6 +78,22 @@ namespace LTL {
             return _checker->max_tokens();
         }
 
+        size_t configurations() const {
+            return _checker->get_configurations();
+        }
+
+        size_t discovered() const {
+            return _checker->get_discovered();
+        }
+
+        size_t markings() const {
+            return _checker->get_markings();
+        }
+
+        size_t explored() const {
+            return _checker->get_explored();
+        }
+
         std::string heuristic_type() const {
             std::stringstream ss;
             if(_heuristic)

--- a/include/LTL/Structures/BitProductStateSet.h
+++ b/include/LTL/Structures/BitProductStateSet.h
@@ -73,6 +73,7 @@ namespace LTL { namespace Structures {
             assert(res.second == get_marking_id(product_id));
             assert(state.get_buchi_state() == get_buchi_state(product_id));
             auto [is_new, data_id] = _states.insert(product_id);
+            if(is_new) ++_configurations;
             return {is_new, product_id, data_id};
         }
 
@@ -104,6 +105,10 @@ namespace LTL { namespace Structures {
 
         size_t max_tokens() const { return _markings.maxTokens(); }
 
+        size_t markings() const { return _markings.size(); }
+
+        size_t configurations() const { return _configurations; }
+
     protected:
 
         static constexpr auto BUCHI_MASK = ~(std::numeric_limits<size_t>::max() << (nbits));
@@ -114,6 +119,7 @@ namespace LTL { namespace Structures {
         static constexpr auto _err_val = std::make_pair(false, std::numeric_limits<size_t>::max());
 
         size_t _discovered = 0;
+        size_t _configurations = 0;
     };
 
     template<uint8_t nbits = 20>

--- a/include/LTL/Structures/CompoundStateSet.h
+++ b/include/LTL/Structures/CompoundStateSet.h
@@ -103,6 +103,10 @@ namespace LTL { namespace Structures {
 
         size_t max_tokens() const { return _markings.maxTokens(); }
 
+        size_t markings() const { return _markings.size(); }
+
+        size_t configurations() const { return _states.size(); }
+
     protected:
 
         static constexpr auto BUCHI_MASK = ~(std::numeric_limits<size_t>::max() << (nbits));

--- a/include/PetriEngine/Structures/StateSet.h
+++ b/include/PetriEngine/Structures/StateSet.h
@@ -66,6 +66,8 @@ namespace PetriEngine {
 
             virtual std::pair<size_t, size_t> getHistory(size_t markingid) = 0;
 
+            virtual size_t size() const = 0;
+
         protected:
             size_t _discovered;
             uint32_t _kbound;
@@ -237,6 +239,10 @@ namespace PetriEngine {
                 return std::make_pair(0,0);
             }
 
+            virtual size_t size() const override {
+                return _trie.size();
+            }
+
         private:
             ptrie_t _trie;
         };
@@ -274,6 +280,10 @@ namespace PetriEngine {
             {
                 assert(false);
                 return std::make_pair(0,0);
+            }
+
+            virtual size_t size() const override {
+                return _trie.size();
             }
 
         protected:

--- a/src/LTL/Algorithm/NestedDepthFirstSearch.cpp
+++ b/src/LTL/Algorithm/NestedDepthFirstSearch.cpp
@@ -155,6 +155,8 @@ namespace LTL {
         }
         _discovered = states.discovered();
         _max_tokens = states.max_tokens();
+        _configurations = states.configurations();
+        _markings = states.markings();
     }
 
     template<typename T, typename S>
@@ -195,6 +197,18 @@ namespace LTL {
 
     size_t NestedDepthFirstSearch::max_tokens() const {
         return _max_tokens;
+    }
+
+    size_t NestedDepthFirstSearch::get_markings() const {
+        return _markings;
+    }
+
+    size_t NestedDepthFirstSearch::get_configurations() const {
+        return _configurations;
+    }
+
+    size_t NestedDepthFirstSearch::get_discovered() const {
+        return _discovered;
     }
 
     void NestedDepthFirstSearch::print_stats(std::ostream &os) const

--- a/src/LTL/Algorithm/TarjanModelChecker.cpp
+++ b/src/LTL/Algorithm/TarjanModelChecker.cpp
@@ -28,6 +28,18 @@ namespace LTL {
         return _max_tokens;
     }
 
+    size_t TarjanModelChecker::get_discovered() const {
+        return _discoverd;
+    }
+
+    size_t TarjanModelChecker::get_markings() const {
+        return _markings;
+    }
+
+    size_t TarjanModelChecker::get_configurations() const {
+        return _markings;
+    }
+
     void TarjanModelChecker::set_partial_order(LTLPartialOrder o)
     {
         if(_net.has_inhibitor())
@@ -193,6 +205,8 @@ namespace LTL {
         }
         _discoverd = seen.discovered();
         _max_tokens = seen.max_tokens();
+        _markings = seen.markings();
+        _configurations = seen.configurations();
         return !_violation;
     }
 


### PR DESCRIPTION
Adds missing statistics for CTL when LTL and reachability engines are called on sub-goals of the formula.
Merge #122 first.