### PR TITLE
Removed the reorder of potencies in RPFS strategy

### DIFF
--- a/include/PetriEngine/Structures/PotencyQueue.h
+++ b/include/PetriEngine/Structures/PotencyQueue.h
@@ -22,14 +22,6 @@ namespace PetriEngine {
                 }
             };
 
-            struct potency_t {
-                uint32_t value;
-                size_t prev;
-                size_t next;
-
-                potency_t(uint32_t v, size_t p, size_t n) : value(v), prev(p), next(n) {};
-            };
-
             PotencyQueue(size_t s = 0);
 
             virtual ~PotencyQueue();
@@ -46,10 +38,8 @@ namespace PetriEngine {
             size_t _size = 0;
             size_t _best;
             uint32_t _currentParentDist;
-            std::vector<potency_t> _potencies;
+            std::vector<uint32_t> _potencies;
             std::vector<std::priority_queue<weighted_t>> _queues;
-
-            void _swapAdjacent(size_t a, size_t b);
 
             void _initializePotencies(size_t nTransitions, uint32_t initValue);
         };

--- a/src/PetriEngine/Structures/PotencyQueue.cpp
+++ b/src/PetriEngine/Structures/PotencyQueue.cpp
@@ -40,8 +40,6 @@ namespace PetriEngine {
 
             _potencies.reserve(nTransitions);
             for (uint32_t i = 0; i < nTransitions; i++) {
-                size_t prev = i == 0 ? SIZE_MAX : i - 1;
-                size_t next = i == nTransitions - 1 ? SIZE_MAX : i + 1;
                 _potencies.push_back(initValue);
             }
             _best = 0;

--- a/src/PetriEngine/Structures/PotencyQueue.cpp
+++ b/src/PetriEngine/Structures/PotencyQueue.cpp
@@ -90,7 +90,7 @@ namespace PetriEngine {
 
                 n += _potencies[t];
                 double r = (double) rand() / RAND_MAX;
-                float threshold = _potencies[t] / (float) n;
+                double threshold = _potencies[t] / (double) n;
                 if (r <= threshold)
                     current = t;
             }


### PR DESCRIPTION
The use of random sampling algorithm in RandomPotencyQueue::pop make the sorting of potencies useless when a value is pushed to the queue.