### PR TITLE
added missing default tuple size for empty tuples

### DIFF
--- a/include/PetriEngine/Colored/Intervals.h
+++ b/include/PetriEngine/Colored/Intervals.h
@@ -296,7 +296,7 @@ namespace PetriEngine {
             }
 
             size_t tupleSize() const {
-                return _intervals[0].size();
+                return _intervals.empty() ? 0 : _intervals[0].size();
             }
 
             uint32_t getContainedColors() const {


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/tapaal/+bug/2012122
Fixes https://bugs.launchpad.net/tapaal/+bug/2012142