### PR TITLE
Fix ControlCondition negation propagation

### DIFF
--- a/src/PetriEngine/PQL/Simplifier.cpp
+++ b/src/PetriEngine/PQL/Simplifier.cpp
@@ -699,7 +699,7 @@ namespace PetriEngine { namespace PQL {
         Visitor::visit(this, condition->getCond());
         if(_return_value.formula->isTriviallyTrue() || _return_value.formula->isTriviallyFalse())
         {
-            bool is_true = _return_value.formula->isTriviallyTrue() xor (!_context.negated());
+            bool is_true = _return_value.formula->isTriviallyTrue() xor (_context.negated());
             RETURN(Retval(is_true ?
                            Retval(BooleanCondition::TRUE_CONSTANT) :
                            Retval(BooleanCondition::FALSE_CONSTANT)))


### PR DESCRIPTION
If the query is trivial (false or true), then the result is true if (isTriviallyTrue XOR negated).
```
formula is trivially... | negated()   || result is...
         false          | not negated ||  false
         false          |   negated   ||  true
         true           | not negated ||  true
         true           |   negated   ||  false
```