### PR TITLE
Bug fix in PetriNetBuilder regarding direction

### DIFF
--- a/src/PetriEngine/PetriNetBuilder.cpp
+++ b/src/PetriEngine/PetriNetBuilder.cpp
@@ -510,9 +510,9 @@ namespace PetriEngine {
                     auto tov = std::make_pair(&net->_invariants[net->_transitions[t].inputs], &net->_invariants[net->_transitions[t].outputs]);
                     for(; tov.first != tov.second; ++tov.first)
                     {
-                        found = true;
                         if(tov.first->place == tiv.first->place)
                         {
+                            found = true;
                             if     (tov.first->inhibitor)                   tiv.first->direction = tov.first->direction = 1;
                             else if(tiv.first->tokens > tov.first->tokens)  tiv.first->direction = tov.first->direction = 1;
                             else if(tiv.first->tokens == tov.first->tokens) tiv.first->direction = tov.first->direction = 0;


### PR DESCRIPTION
I found this misplaced statement while looking through the PetriNetBuilder, possibly failing an assertion on the direction of arcs.

I ran the tests with `run_tests.sh` and no answers changed. However, I didn't give any options to the script since I do not know what the direction field is used for, so the test may not have tested anything. Let me know if I should rerun it with some specific options.