### PR TITLE
Fix bug in colored reduction rule Relevance

### DIFF
--- a/src/PetriEngine/Colored/Reduction/RedRuleRelevance.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRuleRelevance.cpp
@@ -84,10 +84,13 @@ namespace PetriEngine::Colored::Reduction {
                         // Loops that do not alter the marking in the place are not considered relevant to the place.
                         const auto& prtIn = red.getInArc(arc.place, potentiallyRelevantTrans);
                         if (prtIn != potentiallyRelevantTrans.input_arcs.end()) {
-                            if (const auto ms1 = PetriEngine::Colored::extractVarMultiset(*prtIn->expr)){
-                                if (const auto ms2 = PetriEngine::Colored::extractVarMultiset(*prtIn->expr)) {
-                                    if (ms1 == ms2){
-                                        continue;
+                            const auto& prtOut = red.getOutArc(potentiallyRelevantTrans, arc.place);
+                            if (prtOut != potentiallyRelevantTrans.output_arcs.end()) {
+                                if (const auto ms1 = PetriEngine::Colored::extractVarMultiset(*prtIn->expr)) {
+                                    if (const auto ms2 = PetriEngine::Colored::extractVarMultiset(*prtOut->expr)) {
+                                        if (ms1 == ms2) {
+                                            continue;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #155

The rule was mistakingly comparing the in-arc's expression with itself, while it was supposed to compare the expression on the in-arc and the out-arc.