### PR TITLE
Fixing problem with printing traces where reduction was disabled.

### DIFF
--- a/src/PetriEngine/Reachability/ResultPrinter.cpp
+++ b/src/PetriEngine/Reachability/ResultPrinter.cpp
@@ -214,7 +214,7 @@ namespace PetriEngine {
                 transitions.push(p.second);
             }
 
-            auto reducer = reducer ? reducer : builder->getReducer();
+            reducer = reducer ? reducer : builder->getReducer();
             
             if(reducer != nullptr)
                 reducer->initFire(std::cerr);

--- a/src/PetriEngine/Reachability/ResultPrinter.cpp
+++ b/src/PetriEngine/Reachability/ResultPrinter.cpp
@@ -214,6 +214,8 @@ namespace PetriEngine {
                 transitions.push(p.second);
             }
 
+            auto reducer = builder->getReducer();
+            
             if(reducer != nullptr)
                 reducer->initFire(std::cerr);
 

--- a/src/PetriEngine/Reachability/ResultPrinter.cpp
+++ b/src/PetriEngine/Reachability/ResultPrinter.cpp
@@ -214,7 +214,7 @@ namespace PetriEngine {
                 transitions.push(p.second);
             }
 
-            auto reducer = builder->getReducer();
+            auto reducer = reducer ? reducer : builder->getReducer();
             
             if(reducer != nullptr)
                 reducer->initFire(std::cerr);


### PR DESCRIPTION
Partially fixes the problem where CTL trace generator with disabled structural reductions didn't return the tokens in the trace, e.g. the bug report: https://bugs.launchpad.net/tapaal/+bug/2037313