### PR TITLE
Fix stubborn reduction bug involving inhibitor arcs

### DIFF
--- a/include/PetriEngine/Stubborn/StubbornSet.h
+++ b/include/PetriEngine/Stubborn/StubbornSet.h
@@ -185,7 +185,6 @@ namespace PetriEngine {
                     // for this transition.
                     for (; finv < linv; ++finv) {
                         if ((*_parent).marking()[finv->place] < finv->tokens && !finv->inhibitor) {
-                            inhib = false;
                             ok = (_places_seen[finv->place] & PresetSeen) != 0;
                             if(ok)
                                 cand = finv->place;
@@ -193,12 +192,12 @@ namespace PetriEngine {
                             {
                                 if(deps >= dependency(finv->place, false))
                                 {
+                                    inhib = false;
                                     cand = finv->place;
                                     deps = dependency(finv->place, false);
                                 }
                             }
                         } else if ((*_parent)[finv->place] >= finv->tokens && finv->inhibitor) {
-                            inhib = true;
                             ok = (_places_seen[finv->place] & PostsetSeen) != 0;
                             if(ok)
                                 cand = finv->place;
@@ -206,6 +205,7 @@ namespace PetriEngine {
                             {
                                 if(deps >= dependency(finv->place, true))
                                 {
+                                    inhib = true;
                                     cand = finv->place;
                                     deps = dependency(finv->place, true);
                                 }


### PR DESCRIPTION
This PR fixes an ordering-dependant bug in the stubborn set reductions involving presets consisting of mixed arcs and inhibitor arcs. The issue arises from a simple `inhib` flag which should only be updated whenever the corresponding `cand` index is updated.

**Example of wrong behavior:**
Consider the following Petri net and query `EF P0 = 0` ([stub_inhib_test.zip](https://github.com/TAPAAL/verifypn/files/15295037/stub_inhib_test.zip)).
- Running `./verifypn-linux64 stub_inhib_test.pnml stub_inhib_test.xml -x 1 -q 0 -r 0` results in "NOT satisfied",
- Running `./verifypn-linux64 stub_inhib_test.pnml stub_inhib_test.xml -x 1 -q 0 -r 0 -p` results in "satisfied".

The query should be satisfied with trace: T3 T0.
 
![image](https://github.com/TAPAAL/verifypn/assets/21122471/e2edada4-bd09-4d2d-a278-b18adcb157d2)


