### PR TITLE
Improve CI configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -63,7 +63,7 @@ jobs:
           cp build/verifypn/bin/verifypn-linux64 website/verifypn-mcc-linux64
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: linux # The branch the action should deploy to.
           folder: website # The folder the action should deploy.

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -45,11 +45,10 @@ jobs:
           CC=gcc-10 CXX=g++-10 cmake ../ -DCMAKE_BUILD_TYPE=Release -DVERIFYPN_Static=ON -DVERIFYPN_MC_Simplification=OFF -DVERIFYPN_TEST=OFF
           make
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: verifypn-linux64
-          path: build/verifypn/bin/verifypn-linux64
+      - name: Deploy verifypn
+        run: |
+          mkdir -p website
+          cp build/verifypn/bin/verifypn-linux64 website/
 
       - name: BuildMCC
         run: |
@@ -58,8 +57,15 @@ jobs:
           CC=gcc-10 CXX=g++-10 cmake ../ -DCMAKE_BUILD_TYPE=Release -DVERIFYPN_Static=OFF -DVERIFYPN_MC_Simplification=ON -DVERIFYPN_TEST=OFF
           make
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+      - name: Deploy verifypn-mcc
+        run: |
+          mkdir -p website
+          cp build/verifypn/bin/verifypn-linux64 website/verifypn-mcc-linux64
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4
         with:
-          name: verifypn-mcc-linux64
-          path: build/verifypn/bin/verifypn-linux64
+          branch: linux # The branch the action should deploy to.
+          folder: website # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch
+          single-commit: true 


### PR DESCRIPTION
Hi,

So this small patch copies pretty much how I host build artefacts using a gh action called 
github-pages-deploy-action

so contrary to deploy-artifacts, it pushes to a branch of the host repo, in this case we push to "linux" branch, and crushes history so the branch contains binary artefacts but just the last version.

This produces a link that is stable and can be used to distribute this last-build version. It's also easy to click "release" manually, select the branch with the binaries as well as source, and make it into a distribution with a version number/stable.

The link looks like this : https://github.com/yanntm/verifypn/raw/linux/verifypn-mcc-linux64
except in proper repo it will be TAPAAL/verifypn

Essentially it's a raw link to the file on linux branch, ie. https://github.com/yanntm/verifypn/blob/linux/

This link is used in my new adapter for MCC-driver for tapaal : 
https://github.com/yanntm/MCC-drivers/tree/master/tapaal

I copied in the files from your "scripts" folder, added a couple scripts to install/install_packages/supported_examinations for consistency with other tools. But we can now play with tapaal+red if we want.

**
Second edit is to add a dependabot file, configured to be slow/not too aggressive, but that will automatically propose patches for versions of actions used in the workflows. It's convenient I find.

**

Hope you like it, we can exchange by email rather than here if you want more details.

cheers

yann