### PR TITLE
Added check for end in pnml writer

### DIFF
--- a/src/PetriEngine/Colored/PnmlWriter.cpp
+++ b/src/PetriEngine/Colored/PnmlWriter.cpp
@@ -299,8 +299,8 @@ namespace PetriEngine {
             }
             else
             {
-                const std::string& thePnmlColorType = _namedSortTypes.find(c->getColorType()->getName())->second;
-                if (thePnmlColorType == "finite range") {
+                const auto thePnmlColorTypeIt = _namedSortTypes.find(c->getColorType()->getName());
+                if (thePnmlColorTypeIt != _namedSortTypes.end() && thePnmlColorTypeIt->second == "finite range") {
                     const std::string& start = c->getColorType()->operator[](size_t{0}).getColorName();
                     const std::string& end = c->getColorType()->operator[](
                             c->getColorType()->size() - 1).getColorName();


### PR DESCRIPTION
When looking up `_namedSortTypes` there is no handling for end. So when it does the following comparison, it just reads garbage data or causes a segmentation fault. It is my understanding that this has not caused issues before by pure luck. 