### PR TITLE
Update build-linux.yml

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -42,24 +42,12 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          CC=gcc-14 CXX=g++-14 cmake ../ -DCMAKE_BUILD_TYPE=Release -DVERIFYPN_Static=ON -DVERIFYPN_MC_Simplification=OFF -DVERIFYPN_TEST=OFF
+          # We create a static binary with parallel simplification - works both for the MCC competition as well as releases
+          CC=gcc-14 CXX=g++-14 cmake ../ -DCMAKE_BUILD_TYPE=Release -DVERIFYPN_Static=ON -DVERIFYPN_MC_Simplification=ON -DVERIFYPN_TEST=OFF
           make
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: verifypn-linux64
-          path: build/verifypn/bin/verifypn-linux64
-
-      - name: BuildMCC
-        run: |
-          mkdir -p build
-          cd build
-          CC=gcc-14 CXX=g++-14 cmake ../ -DCMAKE_BUILD_TYPE=Release -DVERIFYPN_Static=OFF -DVERIFYPN_MC_Simplification=ON -DVERIFYPN_TEST=OFF
-          make
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: verifypn-mcc-linux64
           path: build/verifypn/bin/verifypn-linux64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,6 @@ set(VERIFYPN_OSX_DEPLOYMENT_TARGET 10.8 CACHE STRING "Specify the minimum versio
 
 ## Configure Static
 if (VERIFYPN_Static)
-    if (VERIFYPN_MC_Simplification)
-        message( FATAL_ERROR "Multicore Simplification is not compatible with static linking")
-    endif (VERIFYPN_MC_Simplification)
     set(BUILD_SHARED_LIBS OFF)
     if (NOT APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")


### PR DESCRIPTION
Compiles now only one linux binary - with static linking as well as with enabled parallel simplifiaction for MCC