### PR TITLE
Made preemptive firing reduction remove transition as well

### DIFF
--- a/src/PetriEngine/Colored/Reduction/RedRulePreemptiveFiring.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRulePreemptiveFiring.cpp
@@ -47,6 +47,7 @@ namespace PetriEngine::Colored::Reduction {
 
             if (place._pre.empty()) {
                 red.skipPlace(p);
+                red.skipTransition(place._post[0]);
             } else {
                 place.marking = Multiset();
             }


### PR DESCRIPTION
The preemptive firing reduction can remove places if they have no pre places. However, the associated transition is not removed which causes the transition to be fireable arbitrarily many times. This PR deletes the transition as well.

I have attached an example net where this happens in the comments of the associated bug report. [direct link to the comment](https://bugs.launchpad.net/tapaal/+bug/2092210/comments/6)