### PR TITLE
Dead transition reduction should handle more than 10000 bindings correctly

### DIFF
--- a/src/PetriEngine/Colored/Reduction/RedRuleDeadTransitions.cpp
+++ b/src/PetriEngine/Colored/Reduction/RedRuleDeadTransitions.cpp
@@ -60,7 +60,10 @@ namespace PetriEngine::Colored::Reduction {
 
                 //slightly more expensive check
                 uint32_t bindingCount = red.getBindingCount(t);
-                if (bindingCount > 10000) continue;
+                if (bindingCount > 10000) {
+                    ok = false;
+                    continue;
+                }
                 //lets actually look at the tokens and see if a binding enables the arc to the transition
                 if (markingEnablesInArc(place.marking, *in, t, partition, red.colors())) {
                     //If there is no output, continue as it clearly cannot have an increasing effect on the place


### PR DESCRIPTION
When there are more than 10000 bindings on a binding, they are not checked and defaults to never being fireable. This makes the reduction always active in such cases. This PR disables the reduction in such cases.

Fixes this bug https://bugs.launchpad.net/tapaal/+bug/2100582
