### PR TITLE
Engine ignoring new markings

### DIFF
--- a/src/PetriEngine/ExplicitColored/ExplicitColoredInteractiveMode.cpp
+++ b/src/PetriEngine/ExplicitColored/ExplicitColoredInteractiveMode.cpp
@@ -70,7 +70,7 @@ namespace PetriEngine::ExplicitColored {
             }
 
             if (inputXml.first_node()->name() == std::string("marking")) {
-                auto markingOption = _parseMarking(initialMarkingXml, std::cerr);
+                auto markingOption = _parseMarking(inputXml, std::cerr);
 
                 if (!markingOption.has_value()) {
                     return 1;


### PR DESCRIPTION
The engine ignores new markings send after the first one.

Try running interactive mode with the following net:
[interactive-test.txt](https://github.com/user-attachments/files/21748870/interactive-test.txt)

and give it the following sequence

1.
`<marking>
    <place id="ComposedModel_P2">
        <token count="1">
            <color>1</color>
        </token>
        <token count="1">
            <color>6</color>
        </token>
    </place>
</marking>`

2.
`<transition id="ComposedModel_T1">
    <binding>
        <variable id="x">
            <color>1</color>
        </variable>
    </binding>
</transition>`

3.
`<marking>
    <place id="ComposedModel_P3">
        <token count="1">
            <color>1</color>
        </token>
    </place>
    <place id="ComposedModel_P2">
        <token count="1">
            <color>6</color>
        </token>
    </place>
</marking>`

the engine returns:
`<valid-bindings>
        <transition id="ComposedModel_T1">
                <binding>
                        <variable id="x">
                                <color>1</color>
                        </variable>
                </binding>
                <binding>
                        <variable id="x">
                                <color>6</color>
                        </variable>
                </binding>
        </transition>
        <transition id="ComposedModel_T2">
                <binding>
                        <variable id="y">
                                <color>1</color>
                        </variable>
                </binding>
                <binding>
                        <variable id="y">
                                <color>6</color>
                        </variable>
                </binding>
        </transition>
</valid-bindings>`

but expected is:
`<valid-bindings>
        <transition id="ComposedModel_T1">
                <binding>
                        <variable id="x">
                                <color>6</color>
                        </variable>
                </binding>
        </transition>
        <transition id="ComposedModel_T2">
                <binding>
                        <variable id="y">
                                <color>6</color>
                        </variable>
                </binding>
        </transition>
</valid-bindings>`

because the engine returns the same valid bindings as after inputting the first marking command