### PR TITLE
Colored inhibitor parsing does not match gui output - fix 2120658

### DIFF
--- a/src/PetriParse/PNMLParser.cpp
+++ b/src/PetriParse/PNMLParser.cpp
@@ -711,23 +711,6 @@ void PNMLParser::parseArc(rapidxml::xml_node<>* element, bool inhibitor) {
     if(weightTag != nullptr) {
         weight = atoi(weightTag->value());
         assert(weight > 0);
-    } else if (isColored && inhibitor) {
-        auto hlin = element->first_node("hlinscription");
-        if (hlin != nullptr) {
-            auto structure = hlin->first_node("structure");
-            if (structure != nullptr) {
-                auto numberOf = structure->first_node("numberof");
-                if (numberOf != nullptr) {
-                    for (auto subterm = numberOf->first_node("subterm"); subterm; subterm = subterm->next_sibling("subterm")) {
-                        auto numberConstant = subterm->first_node("numberconstant");
-                        if (numberConstant != nullptr) {
-                            auto valueTag = numberConstant->first_attribute("value");
-                            weight = atoi(valueTag->value());
-                        }
-                    }
-                }
-            }
-        }
     } else {
         for (auto it = element->first_node("inscription"); it; it = it->next_sibling("inscription")) {
             std::string text;


### PR DESCRIPTION
Engine fix for:
https://bugs.launchpad.net/tapaal/+bug/2120658