### PR TITLE
Empty marking causes segfault in interactive mode in explicit engine - 2120824

### DIFF
--- a/src/PetriEngine/ExplicitColored/ExplicitColoredInteractiveMode.cpp
+++ b/src/PetriEngine/ExplicitColored/ExplicitColoredInteractiveMode.cpp
@@ -174,6 +174,11 @@ namespace PetriEngine::ExplicitColored {
             errorOut << "Unexpected tag " << std::quoted(root->name()) << std::endl;
             return std::nullopt;
         }
+
+        if (placeNode == nullptr) {
+            return generatedMarking; // Empty marking
+        }
+
         do {
             if (placeNode->name() != std::string("place")) {
                 errorOut << "Unexpected tag " << std::quoted(placeNode->name()) << std::endl;


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2120824