### PR TITLE
Multi-thread build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p build
           cd build
           CC=gcc-14 CXX=g++-14 cmake ../ -DCMAKE_BUILD_TYPE=Debug -DVERIFYPN_Static=OFF -DVERIFYPN_MC_Simplification=OFF -DVERIFYPN_TEST=ON
-          make
+          make -j$(nproc)
           CTEST_OUTPUT_ON_FAILURE=1 make test
 
       - name: Build
@@ -44,7 +44,7 @@ jobs:
           cd build
           # We create a static binary with parallel simplification - works both for the MCC competition as well as releases
           CC=gcc-14 CXX=g++-14 cmake ../ -DCMAKE_BUILD_TYPE=Release -DVERIFYPN_Static=ON -DVERIFYPN_MC_Simplification=ON -DVERIFYPN_TEST=OFF
-          make
+          make -j$(nproc)
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,14 +21,7 @@ jobs:
       - name: Install Packages
         run: |
           sudo apt-get update
-          sudo apt-get install flex libboost-all-dev
-
-          wget https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz
-          tar xvfz bison-3.7.6.tar.gz
-          cd bison-3.7.6
-          ./configure
-          make
-          sudo make install
+          sudo apt-get install flex libboost-all-dev bison
 
       - name: Test
         run: |

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -21,15 +21,8 @@ jobs:
       - name: Install Packages
         run: |
           sudo apt-get update
-          sudo apt-get install flex
+          sudo apt-get install flex bison
           sudo apt-get install mingw-w64-x86-64-dev mingw-w64-tools g++-mingw-w64-x86-64 wine wine-binfmt
-
-          wget https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz
-          tar xvfz bison-3.7.6.tar.gz
-          cd bison-3.7.6
-          ./configure
-          make 
-          sudo make install
 
       - name: Build 
         uses: lukka/run-cmake@v2.5
@@ -42,6 +35,8 @@ jobs:
           cmakeBuildType: Release
           cmakeGenerator: UnixMakefiles
           buildDirectory: '${{runner.workspace}}/build'     
+          buildWithCMake: true
+          buildWithCMakeArgs: -- -j$(nproc)
       - name: Upload artifacts 
         uses: actions/upload-artifact@v4
         with:

--- a/src/CTL/CMakeLists.txt
+++ b/src/CTL/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(SearchStrategy)
 
 add_library(CTL ${HEADER_FILES}
 CTLEngine.cpp CTLResult.cpp)
+add_dependencies(PetriNets ptrie-ext spot-ext)
 
 target_link_libraries(CTL Algorithm DependencyGraph PetriNets SearchStrategy)
 

--- a/src/CTL/PetriNets/CMakeLists.txt
+++ b/src/CTL/PetriNets/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(PetriNets OnTheFlyDG.cpp)
-add_dependencies(PetriNets ptrie-ext)
+add_dependencies(PetriNets ptrie-ext glpk-ext)
 target_link_libraries(PetriNets PetriEngine DependencyGraph)

--- a/src/CTL/SearchStrategy/CMakeLists.txt
+++ b/src/CTL/SearchStrategy/CMakeLists.txt
@@ -3,3 +3,4 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_library(SearchStrategy HeuristicSearch.cpp
 RDFSSearch.cpp
 SearchStrategy.cpp)
+add_dependencies(SearchStrategy glpk-ext)

--- a/src/LTL/Algorithm/CMakeLists.txt
+++ b/src/LTL/Algorithm/CMakeLists.txt
@@ -4,5 +4,5 @@ add_library(LTL_algorithm ${HEADER_FILES}
         NestedDepthFirstSearch.cpp LTLToBuchi.cpp TarjanModelChecker.cpp)
 
 target_link_libraries(LTL_algorithm PetriEngine LTLStubborn)
-add_dependencies(LTL_algorithm ptrie-ext spot-ext)
+add_dependencies(LTL_algorithm glpk-ext ptrie-ext spot-ext)
 

--- a/src/LTL/Simplification/CMakeLists.txt
+++ b/src/LTL/Simplification/CMakeLists.txt
@@ -3,6 +3,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_library(LTL_simplification ${HEADER_FILES}
         SpotToPQL.cpp)
 
-add_dependencies(LTL_simplification spot-ext)
+add_dependencies(LTL_simplification glpk-ext spot-ext)
 target_link_libraries(LTL_simplification LTL_algorithm PetriEngine)
 

--- a/src/LTL/Stubborn/CMakeLists.txt
+++ b/src/LTL/Stubborn/CMakeLists.txt
@@ -3,4 +3,4 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_library(LTLStubborn LTLEvalAndSetVisitor.cpp VisibleTransitionVisitor.cpp VisibleLTLStubbornSet.cpp
                         AutomatonStubbornSet.cpp SafeAutStubbornSet.cpp)
 target_link_libraries(LTLStubborn PetriEngine)
-add_dependencies(LTLStubborn spot-ext)
+add_dependencies(LTLStubborn glpk-ext spot-ext)

--- a/src/LTL/SuccessorGeneration/CMakeLists.txt
+++ b/src/LTL/SuccessorGeneration/CMakeLists.txt
@@ -2,5 +2,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(LTLSuccessorGeneration ${HEADER_FILES} ResumingSuccessorGenerator.cpp CompoundGenerator.cpp AutomatonHeuristic.cpp)
 
-target_link_libraries(LTLSuccessorGeneration bddx spot)
+target_link_libraries(LTLSuccessorGeneration bddx)
+add_dependencies(LTLSuccessorGeneration glpk-ext spot-ext)
 

--- a/src/PetriEngine/CMakeLists.txt
+++ b/src/PetriEngine/CMakeLists.txt
@@ -21,3 +21,4 @@ add_library(PetriEngine ${HEADER_FILES}
     options.cpp)
 
 target_link_libraries(PetriEngine PRIVATE Colored ColoredReduction Structures Simplification Stubborn Reachability PQL TAR Synthesis ExplicitColored)
+add_dependencies(PetriEngine glpk-ext ptrie-ext rapidxml-ext spot-ext)

--- a/src/PetriEngine/Colored/Reduction/CMakeLists.txt
+++ b/src/PetriEngine/Colored/Reduction/CMakeLists.txt
@@ -11,3 +11,4 @@ add_library(ColoredReduction ${HEADER_FILES}
         RedRulePreemptiveFiring.cpp)
 
 target_link_libraries(ColoredReduction Colored)
+add_dependencies(ColoredReduction glpk-ext rapidxml-ext)

--- a/src/PetriEngine/ExplicitColored/CMakeLists.txt
+++ b/src/PetriEngine/ExplicitColored/CMakeLists.txt
@@ -17,3 +17,4 @@ add_library(ExplicitColored
 )
 
 target_link_libraries(ExplicitColored Colored)
+add_dependencies(ExplicitColored glpk-ext ptrie-ext rapidxml-ext)

--- a/src/PetriEngine/Stubborn/CMakeLists.txt
+++ b/src/PetriEngine/Stubborn/CMakeLists.txt
@@ -2,4 +2,4 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(Stubborn ReachabilityStubbornSet.cpp StubbornSet.cpp InterestingTransitionVisitor.cpp)
 target_link_libraries(Stubborn PetriEngine)
-# add_dependencies(Stubborn )
+add_dependencies(Stubborn glpk-ext)

--- a/src/PetriEngine/Synthesis/CMakeLists.txt
+++ b/src/PetriEngine/Synthesis/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 add_library(Synthesis ${HEADER_FILES} SimpleSynthesis.cpp GameSuccessorGenerator.cpp GamePORSuccessorGenerator.cpp GameStubbornSet.cpp)
 target_link_libraries(Synthesis PetriEngine)
+add_dependencies(PetriNets glpk-ext ptrie-ext)

--- a/src/PetriEngine/TAR/CMakeLists.txt
+++ b/src/PetriEngine/TAR/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(TAR ${HEADER_FILES} TraceSet.cpp Solver.cpp TARReachability.cpp RangeContext.cpp RangeEvalContext.cpp)
 target_link_libraries(TAR PQL)
-add_dependencies(TAR glpk-ext ptrie-ext)
+add_dependencies(TAR glpk-ext ptrie-ext rapidxml-ext)

--- a/src/PetriParse/CMakeLists.txt
+++ b/src/PetriParse/CMakeLists.txt
@@ -2,4 +2,4 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(PetriParse ${HEADER_FILES} AbstractPetriNetBuilder.cpp PNMLParser.cpp QueryBinaryParser.cpp QueryXMLParser.cpp)
 target_link_libraries(PetriParse Colored PetriEngine)
-add_dependencies(PetriParse rapidxml-ext)
+add_dependencies(PetriParse glpk-ext rapidxml-ext)


### PR DESCRIPTION
Uses more cores to build the binaries, resulting in a reduced usage time.

This required to update some dependency usages for some targets.